### PR TITLE
feat: character, preference API

### DIFF
--- a/eduve/src/main/java/tricode/eduve/controller/AllCharacterController.java
+++ b/eduve/src/main/java/tricode/eduve/controller/AllCharacterController.java
@@ -1,0 +1,30 @@
+package tricode.eduve.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tricode.eduve.dto.AllCharacterResponseDto;
+import tricode.eduve.dto.CharacterUnitDto;
+import tricode.eduve.service.AllCharacterService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/characters")
+public class AllCharacterController {
+    private final AllCharacterService allCharacterService;
+
+    //모든 기본 캐릭터 정보 조회
+    @GetMapping
+    public ResponseEntity<AllCharacterResponseDto> getAllCharacters() {
+        return ResponseEntity.ok(allCharacterService.getAllCharacters());
+    }
+
+    // 캐릭터 하나 조회
+    @GetMapping("/{allCharacterId}")
+    public ResponseEntity<CharacterUnitDto> getOneCharacters(@PathVariable Long allCharacterId) {
+        return ResponseEntity.ok(allCharacterService.getOneCharacters(allCharacterId));
+    }
+}

--- a/eduve/src/main/java/tricode/eduve/controller/UserCharacterController.java
+++ b/eduve/src/main/java/tricode/eduve/controller/UserCharacterController.java
@@ -1,9 +1,28 @@
 package tricode.eduve.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tricode.eduve.dto.UserCharacterPreferenceDto;
+import tricode.eduve.dto.UserCharacterPreferenceRequestDto;
+import tricode.eduve.service.UserCharacterService;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/userCharacter")
 public class UserCharacterController {
+
+    private final UserCharacterService userCharacterService;
+
+    //사용자 캐릭터 정보 설정
+    @PatchMapping("/{userId}")
+    public ResponseEntity<UserCharacterPreferenceDto> updateUserCharacter(@PathVariable Long userId, @RequestBody UserCharacterPreferenceRequestDto requestDto) {
+        return ResponseEntity.ok(userCharacterService.updateUserCharacter(userId, requestDto));
+    }
+
+    //사용자 캐릭터 정보 조회
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserCharacterPreferenceDto> getUserCharacterPreference(@PathVariable Long userId) {
+        return ResponseEntity.ok(userCharacterService.getUserCharacterPreference(userId));
+    }
 }

--- a/eduve/src/main/java/tricode/eduve/domain/DescriptionLevel.java
+++ b/eduve/src/main/java/tricode/eduve/domain/DescriptionLevel.java
@@ -1,0 +1,5 @@
+package tricode.eduve.domain;
+
+public enum DescriptionLevel {
+    HIGH, MEDIUM, LOW;
+}

--- a/eduve/src/main/java/tricode/eduve/domain/Preference.java
+++ b/eduve/src/main/java/tricode/eduve/domain/Preference.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Preference {
@@ -15,12 +16,22 @@ public class Preference {
     @Id
     @Column(name = "preference_id", nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int preferenceId;
+    private Long preferenceId;
 
+    @Enumerated(EnumType.STRING) // Enum을 문자열로 저장
     @Column(nullable = false)
-    private String tone;
+    private Tone tone;
 
+    @Enumerated(EnumType.STRING) // Enum을 문자열로 저장
     @Column(nullable = false)
-    private String descriptionLevel;
+    private DescriptionLevel descriptionLevel;
 
+
+    // 기본값을 설정하는 메서드
+    public static Preference createDefaultPreference() {
+        Preference preference = new Preference();
+        preference.setTone(Tone.FRIENDLY);
+        preference.setDescriptionLevel(DescriptionLevel.MEDIUM);
+        return preference;
+    }
 }

--- a/eduve/src/main/java/tricode/eduve/domain/Tone.java
+++ b/eduve/src/main/java/tricode/eduve/domain/Tone.java
@@ -1,0 +1,5 @@
+package tricode.eduve.domain;
+
+public enum Tone {
+    FORMAL, CASUAL, FRIENDLY, PROFESSIONAL;
+}

--- a/eduve/src/main/java/tricode/eduve/domain/UserCharacter.java
+++ b/eduve/src/main/java/tricode/eduve/domain/UserCharacter.java
@@ -33,4 +33,16 @@ public class UserCharacter {
     @JoinColumn(name = "preference_id", nullable = false)
     private Preference preference;
 
+
+    // 기본값을 설정하는 메서드
+    public static UserCharacter createDefaultUserCharacter(User user, AllCharacter character) {
+        UserCharacter userCharacter = new UserCharacter();
+        userCharacter.setUser(user);
+        // characterId 1인 캐릭터 가져와서 파라미터 넣어주면 될 듯
+        userCharacter.setCharacter(character);
+        userCharacter.setUserCharacterName(character.getCharacterName());
+        // 기본 Preference 설정
+        userCharacter.setPreference(Preference.createDefaultPreference());
+        return userCharacter;
+    }
 }

--- a/eduve/src/main/java/tricode/eduve/dto/AllCharacterResponseDto.java
+++ b/eduve/src/main/java/tricode/eduve/dto/AllCharacterResponseDto.java
@@ -1,0 +1,14 @@
+package tricode.eduve.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class AllCharacterResponseDto {
+    List<CharacterUnitDto> AllCharacterList;
+}

--- a/eduve/src/main/java/tricode/eduve/dto/CharacterUnitDto.java
+++ b/eduve/src/main/java/tricode/eduve/dto/CharacterUnitDto.java
@@ -1,0 +1,25 @@
+package tricode.eduve.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import tricode.eduve.domain.AllCharacter;
+import tricode.eduve.domain.UserCharacter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CharacterUnitDto {
+    private Long characterId;
+    private String characterName;
+    //private String characterImgUrl;
+
+    public static CharacterUnitDto from(AllCharacter character) {
+        return new CharacterUnitDto(
+                character.getAllCharacterId(),
+                character.getCharacterName()
+        );
+    }
+}

--- a/eduve/src/main/java/tricode/eduve/dto/UserCharacterPreferenceDto.java
+++ b/eduve/src/main/java/tricode/eduve/dto/UserCharacterPreferenceDto.java
@@ -11,7 +11,7 @@ import tricode.eduve.domain.UserCharacter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserCharacterPreferenceDto {
-    private Long preferenceId;
+    private Long characterId;
     private String userCharacterName;
     private Long userCharacterId;
     //private String userCharacterImgUrl;
@@ -20,7 +20,7 @@ public class UserCharacterPreferenceDto {
 
     public static UserCharacterPreferenceDto from(UserCharacter userCharacter) {
         return new UserCharacterPreferenceDto(
-                userCharacter.getPreference().getPreferenceId(),
+                userCharacter.getCharacter().getAllCharacterId(),
                 userCharacter.getUserCharacterName(),
                 userCharacter.getUserCharacterId(),
                 userCharacter.getPreference().getTone().name(),  // Enum을 String으로 변환

--- a/eduve/src/main/java/tricode/eduve/dto/UserCharacterPreferenceDto.java
+++ b/eduve/src/main/java/tricode/eduve/dto/UserCharacterPreferenceDto.java
@@ -1,0 +1,30 @@
+package tricode.eduve.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import tricode.eduve.domain.UserCharacter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCharacterPreferenceDto {
+    private Long preferenceId;
+    private String userCharacterName;
+    private Long userCharacterId;
+    //private String userCharacterImgUrl;
+    private String tone;
+    private String descriptionLevel;
+
+    public static UserCharacterPreferenceDto from(UserCharacter userCharacter) {
+        return new UserCharacterPreferenceDto(
+                userCharacter.getPreference().getPreferenceId(),
+                userCharacter.getUserCharacterName(),
+                userCharacter.getUserCharacterId(),
+                userCharacter.getPreference().getTone().name(),  // Enum을 String으로 변환
+                userCharacter.getPreference().getDescriptionLevel().name()  // Enum을 String으로 변환
+        );
+    }
+}

--- a/eduve/src/main/java/tricode/eduve/dto/UserCharacterPreferenceRequestDto.java
+++ b/eduve/src/main/java/tricode/eduve/dto/UserCharacterPreferenceRequestDto.java
@@ -1,0 +1,16 @@
+package tricode.eduve.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCharacterPreferenceRequestDto {
+    private String userCharacterName; // 사용자 캐릭터 이름
+    private String tone; // 말투
+    private String descriptionLevel; // 설명 난이도
+}

--- a/eduve/src/main/java/tricode/eduve/dto/UserCharacterPreferenceRequestDto.java
+++ b/eduve/src/main/java/tricode/eduve/dto/UserCharacterPreferenceRequestDto.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserCharacterPreferenceRequestDto {
+    private Long characterId;
     private String userCharacterName; // 사용자 캐릭터 이름
     private String tone; // 말투
     private String descriptionLevel; // 설명 난이도

--- a/eduve/src/main/java/tricode/eduve/repository/AllCharacterRepository.java
+++ b/eduve/src/main/java/tricode/eduve/repository/AllCharacterRepository.java
@@ -1,7 +1,9 @@
 package tricode.eduve.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import tricode.eduve.domain.AllCharacter;
 
+@Repository
 public interface AllCharacterRepository extends JpaRepository<AllCharacter, Long> {
 }

--- a/eduve/src/main/java/tricode/eduve/repository/UserCharacterRepository.java
+++ b/eduve/src/main/java/tricode/eduve/repository/UserCharacterRepository.java
@@ -1,7 +1,13 @@
 package tricode.eduve.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import tricode.eduve.domain.User;
 import tricode.eduve.domain.UserCharacter;
 
+import java.util.Optional;
+
+@Repository
 public interface UserCharacterRepository extends JpaRepository<UserCharacter, Long> {
+    Optional<UserCharacter> findByUser(User user);
 }

--- a/eduve/src/main/java/tricode/eduve/service/AllCharacterService.java
+++ b/eduve/src/main/java/tricode/eduve/service/AllCharacterService.java
@@ -1,0 +1,33 @@
+package tricode.eduve.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import tricode.eduve.domain.AllCharacter;
+import tricode.eduve.dto.AllCharacterResponseDto;
+import tricode.eduve.dto.CharacterUnitDto;
+import tricode.eduve.repository.AllCharacterRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AllCharacterService {
+    private final AllCharacterRepository allCharacterRepository;
+
+    public AllCharacterResponseDto getAllCharacters() {
+        List<AllCharacter> allCharacters = allCharacterRepository.findAll();
+        List<CharacterUnitDto> characterDtos = allCharacters.stream()
+                .map(character -> new CharacterUnitDto(character.getAllCharacterId(), character.getCharacterName()))
+                .collect(Collectors.toList());
+        return new AllCharacterResponseDto(characterDtos);
+    }
+
+    public CharacterUnitDto getOneCharacters(Long allCharacterId) {
+        return allCharacterRepository.findById(allCharacterId)
+                .map(character -> new CharacterUnitDto(character.getAllCharacterId(), character.getCharacterName()))
+                .orElseThrow(() -> new RuntimeException("Character not found with id " + allCharacterId));
+    }
+}

--- a/eduve/src/main/java/tricode/eduve/service/UserCharacterService.java
+++ b/eduve/src/main/java/tricode/eduve/service/UserCharacterService.java
@@ -1,0 +1,74 @@
+package tricode.eduve.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import tricode.eduve.domain.*;
+import tricode.eduve.dto.UserCharacterPreferenceDto;
+import tricode.eduve.dto.UserCharacterPreferenceRequestDto;
+import tricode.eduve.repository.UserCharacterRepository;
+import tricode.eduve.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class UserCharacterService {
+
+    private final UserCharacterRepository userCharacterRepository;
+    private final UserRepository userRepository;
+
+    // userId로 캐릭터 설정 업데이트
+    public UserCharacterPreferenceDto updateUserCharacter(Long userId, UserCharacterPreferenceRequestDto requestDto) {
+        UserCharacter userCharacter = getUserCharacter(userId);
+
+        if (requestDto.getUserCharacterName() != null) {
+            userCharacter.setUserCharacterName(requestDto.getUserCharacterName());
+        }
+
+        // 기존 Preference 객체를 가져와서 업데이트
+        Preference preference = userCharacter.getPreference();
+
+        if (requestDto.getTone() != null) {
+            // Tone 값이 Enum에 존재하는지 확인
+            try {
+                Tone toneEnum = Tone.valueOf(requestDto.getTone());  // ToneEnum을 enum으로 변환
+                preference.setTone(toneEnum);  // 유효한 값이면 설정
+            } catch (IllegalArgumentException e) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid tone value");  // 유효하지 않으면 400 오류
+            }
+        }
+
+        if (requestDto.getDescriptionLevel() != null) {
+            // DescriptionLevel 값이 Enum에 존재하는지 확인
+            try {
+                DescriptionLevel descriptionLevelEnum = DescriptionLevel.valueOf(requestDto.getDescriptionLevel());  // DescriptionLevelEnum을 enum으로 변환
+                preference.setDescriptionLevel(descriptionLevelEnum);  // 유효한 값이면 설정
+            } catch (IllegalArgumentException e) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid descriptionlevel value");  // 유효하지 않으면 400 오류
+            }
+        }
+
+        userCharacterRepository.save(userCharacter);
+        return UserCharacterPreferenceDto.from(userCharacter);  // UserCharacter -> UserCharacterPreferenceDto
+    }
+
+    // userId로 캐릭터 설정 조회
+    public UserCharacterPreferenceDto getUserCharacterPreference(Long userId) {
+        UserCharacter userCharacter = getUserCharacter(userId);
+        return UserCharacterPreferenceDto.from(userCharacter);  // UserCharacter -> UserCharacterPreferenceDto
+    }
+
+    public UserCharacter getUserCharacter(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new RuntimeException("not found user"));
+
+        return userCharacterRepository.findByUser(user)
+                .orElseThrow(()-> new RuntimeException("not found userCharacter"));
+    }
+}

--- a/eduve/src/main/java/tricode/eduve/service/UserCharacterService.java
+++ b/eduve/src/main/java/tricode/eduve/service/UserCharacterService.java
@@ -9,6 +9,7 @@ import org.springframework.web.server.ResponseStatusException;
 import tricode.eduve.domain.*;
 import tricode.eduve.dto.UserCharacterPreferenceDto;
 import tricode.eduve.dto.UserCharacterPreferenceRequestDto;
+import tricode.eduve.repository.AllCharacterRepository;
 import tricode.eduve.repository.UserCharacterRepository;
 import tricode.eduve.repository.UserRepository;
 
@@ -22,6 +23,7 @@ public class UserCharacterService {
 
     private final UserCharacterRepository userCharacterRepository;
     private final UserRepository userRepository;
+    private final AllCharacterRepository allCharacterRepository;
 
     // userId로 캐릭터 설정 업데이트
     public UserCharacterPreferenceDto updateUserCharacter(Long userId, UserCharacterPreferenceRequestDto requestDto) {
@@ -53,6 +55,13 @@ public class UserCharacterService {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid descriptionlevel value");  // 유효하지 않으면 400 오류
             }
         }
+
+        if (requestDto.getCharacterId() != null) {
+            AllCharacter newCharacter = allCharacterRepository.findById(requestDto.getCharacterId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Character not found"));
+            userCharacter.setCharacter(newCharacter);  // 새로운 캐릭터로 변경
+        }
+
 
         userCharacterRepository.save(userCharacter);
         return UserCharacterPreferenceDto.from(userCharacter);  // UserCharacter -> UserCharacterPreferenceDto


### PR DESCRIPTION
### 구현 내용
- 캐릭터 설정(캐릭터이름+preferece) 변경
- 캐릭터 설정(캐릭터이름+preferece) 조회
- 서비스에서 제공하는 캐릭터 목록조회
- 서비스에서 제공하는 캐릭터 하나 정보 조회

### memo
- preference랑 userCharacter 테이블이 회원이 생성될 때 생성이 안되면 오류나서 회원가입 로직에서 preference랑 userCharacter 테이블 기본값으로 생성해줘야 될 것 같음 -> UserCharacter.java에 기본 객체 생성하는 메서드 만들어 놨으니까 회원가입 로직에서 메서드 호출하고 repository에 저장하면 될 듯!!

### Issue
#6 