### PR TITLE
Fix: 임베딩/유사도검색 flask userId 전달

### DIFF
--- a/eduve/src/main/java/tricode/eduve/controller/FileController.java
+++ b/eduve/src/main/java/tricode/eduve/controller/FileController.java
@@ -46,7 +46,7 @@ public class FileController {
             FileResponseDto fileDto = fileUploadService.uploadFileToS3(file, userId, folderId);
 
             // 2. Flask로 파일 전달하여 임베딩 수행
-            String flaskResult = fileUploadService.embedDocument(file);
+            String flaskResult = fileUploadService.embedDocument(file, userId);
 
             // 3. 결과 합쳐서 JSON으로 반환
             FileUploadResponseDto responseDto = FileUploadResponseDto.builder()

--- a/eduve/src/main/java/tricode/eduve/global/FlaskComponent.java
+++ b/eduve/src/main/java/tricode/eduve/global/FlaskComponent.java
@@ -23,7 +23,7 @@ public class FlaskComponent {
 
 
     // 유사도 검색 flask API 호출
-    public String findSimilarDocuments(String question) {
+    public String findSimilarDocuments(String question, Long userId, Long teacherId) {
         //String flaskApiUrl = "http://13.209.87.47:5000/search";  // Flask API URL (로컬에서 Flask 실행 중이라면 localhost 사용)
         String flaskApiUrl = "http://localhost:5000/search";
 
@@ -32,7 +32,7 @@ public class FlaskComponent {
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         // 요청 바디 설정 (JSON 포맷)
-        String requestBody = "{ \"query\": \"" + question + "\" }";
+        String requestBody = "{ \"query\": \"" + question + "\", \"user_id\": \"" + userId + "\", \"teacher_id\": \"" + teacherId + "\" }";
 
         // HTTP 요청 엔티티 생성
         HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
@@ -61,7 +61,7 @@ public class FlaskComponent {
     }
 
     // 임베딩 API 호출
-    public String embedDocument(MultipartFile file) throws IOException {
+    public String embedDocument(MultipartFile file, Long userId) throws IOException {
         //String url = "http://13.209.87.47:5000/embedding";
         String url = "http://localhost:5000/embedding";
 
@@ -70,6 +70,7 @@ public class FlaskComponent {
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
         body.add("file", new MultipartInputStreamFileResource(file.getInputStream(), file.getOriginalFilename()));
+        body.add("userId", userId.toString());  // user_id를 form-data에 추가
 
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 

--- a/eduve/src/main/java/tricode/eduve/service/ChatService.java
+++ b/eduve/src/main/java/tricode/eduve/service/ChatService.java
@@ -8,10 +8,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import tricode.eduve.domain.Message;
+import tricode.eduve.domain.User;
 import tricode.eduve.dto.request.MessageRequestDto;
 import tricode.eduve.dto.response.message.MessageUnitDto;
 import tricode.eduve.global.ChatGptClient;
 import tricode.eduve.global.FlaskComponent;
+import tricode.eduve.repository.UserRepository;
 
 
 @Service
@@ -22,6 +24,7 @@ public class ChatService {
     private final ChatGptClient chatGptClient;
     private final FlaskComponent flaskComponent;
     private final ConversationService conversationService;
+    private final UserRepository userRepository;
 
     /*
     // 질문을 저장하고 비동기적으로 ChatGPT API 호출
@@ -94,8 +97,20 @@ public class ChatService {
         // 1. Conversation 처리 (주제 유사도검색 + 1시간 기준)
         Message message = conversationService.processUserMessage(userId, userMessage);
 
+
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+        //임시 teacher
+        User teacher = new User();
+        // 연결된 선생님 찾기
+        /*
+        User teacher = userRepository.findTeacherByStudent0(user)
+                    .orElseThrow(() -> new RuntimeException("선생님을 찾을 수 없습니다."));
+         */
         // 질문 유사도 검색
-        String similarDocuments = flaskComponent.findSimilarDocuments(userMessage);
+        String similarDocuments = flaskComponent.findSimilarDocuments(userMessage, userId, teacher.getUserId());
 
         // 2. ChatGPT API 호출
         ResponseEntity<String> response= chatGptClient.chat(userMessage, similarDocuments);

--- a/eduve/src/main/java/tricode/eduve/service/FileUploadService.java
+++ b/eduve/src/main/java/tricode/eduve/service/FileUploadService.java
@@ -133,7 +133,7 @@ public class FileUploadService {
         FileResponseDto textFileInfo = uploadFileToS3(textMultipartFile, userId, folderId);
 
         // 5. Flask 임베딩 호출
-        String flaskResult = embedDocument(textMultipartFile);
+        String flaskResult = embedDocument(textMultipartFile, userId);
 
         return FileUploadResponseDto.builder()
                 .fileInfo(List.of(audioFileInfo, textFileInfo))
@@ -206,8 +206,8 @@ public class FileUploadService {
         return FileResponseDto.from(fileEntity);
     }
 
-    public String embedDocument(MultipartFile file) throws IOException {
-        return flaskComponent.embedDocument(file);
+    public String embedDocument(MultipartFile file, Long userId) throws IOException {
+        return flaskComponent.embedDocument(file, userId);
     }
 
     private java.io.File convertMultipartToFile(MultipartFile file) throws IOException {


### PR DESCRIPTION
- flask 임베딩하고 유사도 검색할 때, 해당 사용자 userId로 collection 만들고 거기에 저장. 유사도 검색할때도 userId랑 선생님의 userId 두 개 받아서 자기collection이랑 선생님 collection에서만 유사도 검색할 수 있게 API 수정함. flask 레포지토리의 develop branch 코드 확인해보세여, 로컬테스트 했어욤
- springboot에서 flask 호출할 때 userId 넘겨주도록 수정했음 -> 근데 이거 로컬테스트 못함